### PR TITLE
feat: userProfile 상태를 DB 정보로 갱신 및 프로필 로직 개선

### DIFF
--- a/eatory-vueproject/src/App.vue
+++ b/eatory-vueproject/src/App.vue
@@ -11,8 +11,12 @@ import { useUserStore } from './stores/userStore';
 import { onMounted } from 'vue';
 
 const store = useUserStore();
-onMounted(()=>{
+onMounted( async ()=>{
   store.restoreSession(); //새로고침 시 세션 복구
+
+  if(store.loginUser) {
+    await store.getUserProfile(store.loginUser.id);
+  }
 })
 
 </script>

--- a/eatory-vueproject/src/components/user/UserProfile.vue
+++ b/eatory-vueproject/src/components/user/UserProfile.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="profile-container">
+  <div class="profile-container" v-if="userProfile && userProfile.username">
     <!-- 사용자 이름 -->
-    <h1>{{ userProfile.username }}</h1>
+    <h1>{{ userProfile.name }}</h1>
     <!-- 프로필 이미지 -->
     <img :src="userProfile.profileImage" alt="Profile Image" class="profile-image" />
     <!-- 피드, 팔로워, 팔로잉 카운트 -->
@@ -16,7 +16,7 @@
     import Allergy 
     <allergyView/> -->
     <div class="allergies">
-      <span v-for="allergy in userProfile.allergies" :key="allergy.allergyName" class="allergy-item">
+      <span v-for="allergy in userProfile.allergies" :key="allergy" class="allergy-item">
         {{ allergy }}
       </span>
       <button @click="addAllergy">+</button>
@@ -28,48 +28,36 @@
       <div>Height {{ userProfile.height }}  cm</div>
     </div>
   </div>
+  <div v-else>
+    <p>Loading Profile ...</p>
+  </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
-import axios from "axios";
+import { computed, onMounted } from "vue";
+import { useUserStore } from "@/stores/userStore";
 
-//props로 전달된 userId를 가져옴
-const props = defineProps(["id"]);
+// userStore 사용
+const store = useUserStore();
 
-// 사용자 프로필 데이터
-// const userProfile = ref({});
+// userProfile 상태를 계산 속성으로 가져옴 
+const userProfile = computed(() => store.userProfile);
+console.log("현재 userProfile 상태:", userProfile.value);
 
-// 사용자 프로필 데이터를 저장할 상태
-const userProfile = ref({
-  username: "",
-  profileImage: "",
-  postCount: 0,
-  followerCount: 0,
-  followeeCount: 0,
-  allergies: [],
-  height: 0,
-  weight: 0,
-});
-
-// API 호출
-onMounted(async () => {
-  try {
-    
-    const response = await axios.get(`/api-user/${props.id}`);
-    console.log("받은 userId:", props.id); //디버깅용 로그 //URL에서 전달된 :id 값 확인 
-    console.log(response.data);
-    userProfile.value = response.data;
-  } catch (error) {
-    console.error("Error fetching user profile:", error.response || error);
-    alert("프로필 정보를 가져오는 중 문제가 발생했습니다.");
+onMounted(() => {
+  if(store.loginUser) {
+    store.getUserProfile(store.loginUser.id).catch((error) => 
+    console.error("프로필 로딩에 에러 발생", error)
+  );
   }
-});
+})
 
-// 알러지 추가 (구현 예정)
+//알러지 추가 기능 (구현 예정)
 const addAllergy = () => {
   alert("알러지 추가 기능은 아직 구현되지 않았습니다.");
 };
+
+
 </script>
 
 <style scoped>

--- a/eatory-vueproject/src/stores/userStore.js
+++ b/eatory-vueproject/src/stores/userStore.js
@@ -21,7 +21,16 @@ const REST_USER_API = `http://localhost:8080/api-user`;
 
 export const useUserStore = defineStore("user", () => {
   const loginUser = ref(null); // 로그인 사용자 데이터
-  const userProfile = ref(null); //프로필 정보 
+  const userProfile = ref({
+    username: "",
+    profileImage: "",
+    postCount: 0,
+    followerCount: 0,
+    followeeCount: 0,
+    allergies: [],
+    height: 0,
+    weight: 0,
+  }); //프로필 정보 
 
   // 로그인 요청
   const userLogin = async (email, password) => {
@@ -58,6 +67,9 @@ export const useUserStore = defineStore("user", () => {
 
     //세션에서 사용자 정보 복구
     loginUser.value = JSON.parse(userInfo);
+
+    //프로필 정보 복구
+    userProfile.value = loginUser.value; //복구된 정보로 초기화
   }
 
   // 회원가입 요청 (호출 방식은 signupStore에서 처리)
@@ -85,7 +97,9 @@ export const useUserStore = defineStore("user", () => {
   //프로필 조회
   const getUserProfile = async (userId) => {
     try {
+      console.log("사용자 프로필 가져오기:", userId);//디버깅 로그 추가 
       const response = await axios.get(`${REST_USER_API}/${userId}`);
+      console.log("Profile data received:", response.data); //응답 데이터 확인 
       userProfile.value = response.data; //프로필 데이터 갱신 
     } catch (error) {
       console.error("프로필 가져오기 실패:", error.response || error);
@@ -121,5 +135,5 @@ export const useUserStore = defineStore("user", () => {
     }
   };
 
-  return { loginUser, userLogin, userSignup, getUser, logoutUser, getUserProfile, restoreSession };
+  return { loginUser,userProfile, userLogin, userSignup, getUser, logoutUser, getUserProfile, restoreSession };
 });


### PR DESCRIPTION
### 작업 내용
1. **로그인 시 userProfile 상태 갱신**
   - 로그인 성공 시 서버에서 반환된 `user` 데이터를 userProfile 상태로 저장.
   - 세션 스토리지에 사용자 정보와 access-token을 저장하여 새로고침에도 로그인 상태 유지.

2. **새로고침 시 프로필 복구 로직 추가**
   - `restoreSession` 함수에서 세션 데이터를 복구하여 로그인 상태와 프로필 상태를 갱신.
   - userProfile이 올바르게 복구되도록 로직 개선 및 `return` 추가.

3. **UserProfile 컴포넌트와 상태 관리**
   - `computed` 속성을 통해 userProfile 상태를 읽어오도록 수정.
   - userProfile이 없을 경우 "로딩 중" 메시지 표시.

4. **Axios interceptor 추가**
   - 모든 Axios 요청에 `access-token` 헤더를 자동으로 추가하도록 설정.

5. **디버깅 로그 추가**
   - 데이터 흐름을 확인할 수 있도록 주요 지점에 로그 추가.

### 테스트
- [o] 로그인 시 userProfile 상태가 업데이트되는지 확인
- [o] 새로고침 후에도 프로필 데이터가 유지되는지 확인
- [o] UserProfile 컴포넌트에 올바르게 정보가 표시되는지 확인
- [o] "로딩 중" 메시지가 정상적으로 표시되는지 확인
- [o] Axios 요청 시 access-token이 헤더에 포함되는지 확인

### 관련 이슈
- Closes #2 

### 스크린샷
로그인 성공 후 UserProfile 화면:  
![image](https://github.com/user-attachments/assets/d77cbbf6-1e83-4236-b095-a432524725ec)

새로고침 후 프로필 유지 확인:  
![image](https://github.com/user-attachments/assets/b5472deb-21f8-4ba3-afb0-30641e810cd8)

### 참고 사항
- 향후 프로필 데이터 갱신이나 수정 기능 추가 시 `getUserProfile` API 재사용 가능.
- 불필요한 디버깅 로그는 최종 QA 후 삭제 필요.
