### PR TITLE
✨ feat: MealType별 Notes 및 기존 기록 관리 로직 추가

### DIFF
--- a/eatory-vueproject/src/components/calendar/CalendarRecord.vue
+++ b/eatory-vueproject/src/components/calendar/CalendarRecord.vue
@@ -1,0 +1,318 @@
+<template>
+  <div>
+    <p class="record-date">현재 날짜: {{ formattedDate }}</p>
+
+    <label>유형:</label>
+    <div class="meal-type-buttons">
+      <button
+        v-for="type in mealTypes"
+        :key="type"
+        :class="['meal-button', { active: type === selectedMealType }]"
+        @click="selectMealType(type)"
+      >
+        {{ type }}
+      </button>
+    </div>
+
+    <label>메뉴:</label>
+    <div class="menu-container">
+      <input
+        type="text"
+        v-model="menuInput"
+        placeholder="메뉴를 선택해주세요"
+        readonly
+      />
+      <button @click="openSearchModal">검색</button>
+    </div>
+
+    <label>메모:</label>
+    <textarea v-model="notesInput" placeholder="메모를 입력하세요"></textarea>
+
+    <div class="modal-actions">
+      <button @click="saveRecord">저장</button>
+      <button
+        @click="deleteCurrentRecord"
+        :disabled="!props.existingRecordData?.find(
+          (record) => record.mealType === selectedMealType
+        )"
+      >
+        삭제
+      </button>
+      <button @click="cancel">닫기</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from "vue";
+import { useModal } from "@/stores/modalPopup";
+import FoodSearchComponent from "@/components/food/FoodSearchComponent.vue";
+import { useRecordStore } from "@/stores/recordStore";
+import { useToastPopup } from "@/stores/toastPopup";
+import CalendarRecord from "@/components/calendar/CalendarRecord.vue";
+
+const props = defineProps({
+  date: String,
+  existingRecordData: Array, // 기존 기록 데이터 배열
+  selectedMealType: {
+    type: String,
+    default: "아침", // 기본값 설정
+  },
+});
+
+const emit = defineEmits(["recordUpdated"]);
+
+const { openModal, closeModal } = useModal();
+const { addRecord, updateRecord, deleteRecord } = useRecordStore();
+const { showToast } = useToastPopup();
+
+const mealTypes = ["아침", "점심", "저녁", "간식"];
+const selectedMealType = ref(props.selectedMealType); // 기본값을 props에서 받아 초기화
+const menuInput = ref(""); // 메뉴 인풋 필드
+const notesInput = ref(""); // 메모 필드
+const recordDate = ref(props.date || new Date().toISOString().split("T")[0]);
+
+const userId = ref(
+  JSON.parse(sessionStorage.getItem("user-info"))?.userId || null
+);
+console.log("초기 userId:", userId.value); // 유저 ID 확인 로그
+
+// 현재 날짜 형식
+const formattedDate = computed(() => {
+  const date = new Date(recordDate.value);
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+});
+
+// 세션에서 메뉴 불러오기 및 menuInput 반영
+const loadSelectedMenuFromSession = () => {
+  const sessionKey = `${recordDate.value}_${selectedMealType.value}`;
+  console.log("세션 키:", sessionKey);
+
+  const sessionData = JSON.parse(sessionStorage.getItem(sessionKey) || "{}");
+  console.log("세션에서 가져온 데이터:", sessionData);
+
+  if (sessionData.selectedMenu) {
+    const existingMenus = menuInput.value.split(",").map((item) => item.trim());
+    console.log("현재 menuInput 값:", existingMenus);
+
+    if (!existingMenus.includes(sessionData.selectedMenu)) {
+      menuInput.value = [...existingMenus, sessionData.selectedMenu].join(", ");
+      console.log("menuInput 업데이트 완료:", menuInput.value);
+    } else {
+      console.log("선택된 메뉴가 이미 존재합니다:", sessionData.selectedMenu);
+    }
+  } else {
+    console.log("세션에서 선택된 메뉴가 없습니다.");
+  }
+};
+
+// MealType에 따른 초기화
+// MealType에 따른 초기화
+const selectMealType = (type) => {
+  selectedMealType.value = type;
+  console.log("선택된 MealType:", selectedMealType.value);
+
+  const sessionKey = `${recordDate.value}_${selectedMealType.value}`;
+  const sessionData = JSON.parse(sessionStorage.getItem(sessionKey) || "{}");
+  console.log("세션 키 확인:", sessionKey);
+  console.log("세션 데이터 확인:", sessionData);
+
+  // 세션 데이터가 있는 경우 menuInput에 반영
+  if (sessionData.selectedMenu) {
+    menuInput.value = sessionData.selectedMenu; // 세션 데이터 사용
+    console.log("세션 데이터로 메뉴 초기화:", menuInput.value);
+  } else {
+    console.log("세션 데이터 없음, 기존 기록 확인 중...");
+
+    // 기존 기록 데이터 확인
+    const recordForMealType = props.existingRecordData?.find(
+      (record) => record.mealType === type
+    );
+
+    if (recordForMealType) {
+      menuInput.value = recordForMealType.menus.join(", ");
+      notesInput.value = recordForMealType.notes;
+      console.log("기존 기록 불러오기 성공:", {
+        menuInput: menuInput.value,
+        notesInput: notesInput.value,
+      });
+    } else {
+      menuInput.value = "";
+      notesInput.value = "";
+      console.log("기존 기록 없음. 초기화 완료.");
+    }
+  }
+};
+
+
+// 음식 검색 모달 열기
+const openSearchModal = () => {
+  const sessionKey = `${recordDate.value}_${selectedMealType.value}`;
+  console.log("검색 모달 열기. sessionKey:", sessionKey);
+
+  openModal("음식 검색", FoodSearchComponent, {
+    searchKeyword: menuInput.value,
+    onFoodSelect: (selectedFood) => {
+      console.log("선택된 음식:", selectedFood.foodName);
+
+      // 세션에 저장
+      sessionStorage.setItem(
+        sessionKey,
+        JSON.stringify({
+          searchKeyword: menuInput.value,
+          selectedMenu: selectedFood.foodName,
+        })
+      );
+      console.log("세션에 저장된 데이터:", sessionStorage.getItem(sessionKey));
+
+      // menuInput 업데이트
+      const existingMenus = menuInput.value
+        .split(",")
+        .map((item) => item.trim());
+      if (!existingMenus.includes(selectedFood.foodName)) {
+        menuInput.value = [...existingMenus, selectedFood.foodName].join(", ");
+      }
+      console.log("menuInput 최종 업데이트:", menuInput.value);
+
+
+      // 현재 모달 닫기
+      closeModal();
+
+      // 짧은 지연 후 해당 날짜 모달 다시 열기
+      setTimeout(() => {
+        console.log("해당 날짜의 모달을 다시 엽니다.");
+        openModal("날짜 기록 추가/수정", CalendarRecord, {
+          date: recordDate.value,
+          existingRecordData: props.existingRecordData,
+          selectedMealType: selectedMealType.value, // 방금 선택한 MealType 유지
+        });
+      }, 300); // 지연 추가
+      // // 상태 동기화
+      // loadSelectedMenuFromSession(); // 세션에서 다시 불러오기
+    },
+  });
+};
+
+// 컴포넌트 초기화
+watch(
+  () => props.existingRecordData,
+  () => {
+    console.log("기존 기록 데이터 변경 감지:", props.existingRecordData);
+    selectMealType(selectedMealType.value);
+  },
+  { immediate: true }
+);
+
+// 저장
+const saveRecord = async () => {
+  console.log("저장 전 userId 확인:", userId.value);
+  console.log("저장 전 menuInput 확인:", menuInput.value);
+
+  if (!menuInput.value.trim() || !notesInput.value.trim()) {
+    showToast("메뉴와 메모를 모두 입력해주세요.", 3000);
+    return;
+  }
+
+  const newRecord = {
+    userId: userId.value,
+    mealType: selectedMealType.value,
+    menus: menuInput.value.split(",").map((item) => item.trim()),
+    notes: notesInput.value.trim(),
+    recordDate: recordDate.value,
+  };
+
+  console.log("생성된 newRecord:", newRecord);
+
+  try {
+    const existingRecord = props.existingRecordData?.find(
+      (record) => record.mealType === selectedMealType.value
+    );
+
+    if (existingRecord?.recordId) {
+      await updateRecord(existingRecord.recordId, newRecord);
+      showToast("기록이 수정되었습니다.", 3000);
+    } else {
+      await addRecord(newRecord);
+      showToast("기록이 추가되었습니다.", 3000);
+    }
+
+    // 세션 초기화
+    const sessionKey = `${recordDate.value}_${selectedMealType.value}`;
+    sessionStorage.removeItem(sessionKey);
+
+    emit("recordUpdated");
+    closeModal();
+    // 새로고침 추가
+    // setTimeout(() => location.reload(), 100); // 짧은 지연 뒤 새로고침
+    window.location.reload();
+  } catch (error) {
+    console.error("기록 저장 중 오류:", error);
+    showToast("기록 저장에 실패했습니다.", 3000);
+  }
+};
+
+const deleteCurrentRecord = async () => {
+    const existingRecord = props.existingRecordData?.find(
+      (record) => record.mealType === selectedMealType.value
+    );
+  
+    if (!existingRecord?.recordId) {
+      console.log("삭제할 기록이 없습니다. MealType:", selectedMealType.value); // 디버깅용 로그  
+      showToast("삭제할 기록이 없습니다.", 3000);
+      return;
+    }
+
+    console.log("삭제하려는 기록 ID:", existingRecord.recordId); // 디버깅용 로그
+  
+    try {
+      await deleteRecord(existingRecord.recordId);
+      showToast("기록이 삭제되었습니다.", 3000);
+  
+      emit("recordUpdated"); // 부모 컴포넌트로 이벤트 전달
+      closeModal();
+      // 새로고침 추가
+      window.location.reload();
+    } catch (error) {
+      console.error("기록 삭제 중 오류:", error);
+      showToast("기록 삭제에 실패했습니다.", 3000);
+    }
+  };
+  
+const cancel = () => {
+  closeModal();
+};
+</script>
+
+<style scoped>
+  .record-date {
+    margin-bottom: 15px;
+    font-size: 1rem;
+    color: #555;
+  }
+  
+  .meal-type-buttons {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+  }
+  
+  .meal-button {
+    padding: 8px 15px;
+    background-color: #ddd;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+  }
+  
+  .meal-button.active {
+    background-color: #87cefa;
+    color: white;
+    font-weight: bold;
+  }
+  
+  .modal-actions {
+    margin-top: 20px;
+    display: flex;
+    gap: 10px;
+  }
+  </style>

--- a/eatory-vueproject/src/components/food/FoodSearchComponent.vue
+++ b/eatory-vueproject/src/components/food/FoodSearchComponent.vue
@@ -1,0 +1,99 @@
+<template>
+    <div>
+      <h2>음식 검색</h2>
+  
+      <div>
+        <input
+          v-model="searchKeyword"
+          placeholder="음식을 입력하세요"
+          @keyup.enter="searchFood"
+        />
+        <button @click="searchFood">검색</button>
+        <button @click="closeModal">닫기</button>
+      </div>
+  
+      <div v-if="foodResults.length > 0" class="food-list">
+        <div
+          v-for="food in foodResults"
+          :key="food.foodCode"
+          class="food-item"
+          @click="selectFood(food)"
+        >
+          <div><strong>{{ food.foodName }}</strong></div>
+          <div>칼로리: {{ food.kcal || "정보 없음" }}</div>
+        </div>
+      </div>
+      <div v-else-if="searchKeyword">검색 결과가 없습니다.</div>
+    </div>
+  </template>
+  
+  <script setup>
+  import { ref } from "vue";
+  import { useModal } from "@/stores/modalPopup";
+  import axios from "axios";
+  
+  const props = defineProps({
+    searchKeyword: String, // 부모에서 전달받은 검색어
+    onFoodSelect: Function, // 부모로부터 전달받은 선택 콜백
+  });
+  
+  const { closeModal } = useModal();
+  
+  const searchKeyword = ref(props.searchKeyword || "");
+//   const foodName = ref("");
+  const foodResults = ref([]);
+  
+  const searchFood = async () => {
+    if (!searchKeyword.value.trim()) {
+      alert("검색어를 입력하세요.");
+      return;
+    }
+  
+    try {
+      const API_URL =
+        "/api/1471000/FoodNtrCpntDbInfo01/getFoodNtrCpntDbInq01";
+      const queryParams = new URLSearchParams({
+        serviceKey:
+          "fQLUPHjJb93JRGQ38cb77pyDsgtE4YSwABGA7RFzTaEVojIU9mXqmCq17rsHmP8d6v2z49i9+oX6DmEajTvb9Q==",
+        pageNo: "1",
+        numOfRows: "5",
+        type: "json",
+        FOOD_NM_KR: searchKeyword.value,
+      });
+  
+      const response = await axios.get(`${API_URL}?${queryParams.toString()}`);
+      const items = response.data.body?.items || [];
+      foodResults.value = items.map((item) => ({
+        foodCode: item.FOOD_CD,
+        foodName: item.FOOD_NM_KR,
+        kcal: item.AMT_NUM1,
+      }));
+    } catch (error) {
+      console.error("검색 실패:", error);
+      foodResults.value = [];
+    }
+  };
+  
+  const selectFood = (food) => {
+    props.onFoodSelect?.(food); // 부모에게 선택된 음식 전달
+    closeModal();
+  };
+  </script>
+  
+  <style scoped>
+  .food-list {
+    margin-top: 10px;
+  }
+  
+  .food-item {
+    padding: 10px;
+    border: 1px solid #ddd;
+    margin-bottom: 10px;
+    cursor: pointer;
+  }
+  
+  .food-item:hover {
+    background-color: #f9f9f9;
+  }
+  </style>
+  

--- a/eatory-vueproject/src/stores/modalPopup.js
+++ b/eatory-vueproject/src/stores/modalPopup.js
@@ -7,6 +7,11 @@ const propsData = ref({}); // 전달할 추가 데이터
 const actions = ref([]);
 
 export const openModal = (modalTitle, modalContent, modalProps = {}, modalActions = []) => {
+  console.log("모달 열기 호출됨");
+  console.log("제목:", modalTitle);
+  console.log("컴포넌트:", modalContent);
+  console.log("전달 데이터 (props):", modalProps);
+  
   title.value = modalTitle;
   content.value = markRaw(modalContent); // 컴포넌트를 처리할 때 markRaw 사용
   propsData.value = modalProps; // 전달할 데이터 저장
@@ -15,6 +20,8 @@ export const openModal = (modalTitle, modalContent, modalProps = {}, modalAction
 };
 
 export const closeModal = async () => {
+  console.log("모달 닫기 호출됨");
+  console.log("초기화 전 상태:", { isVisible: isVisible.value, propsData: propsData.value });
   await new Promise((resolve) => setTimeout(resolve, 50));
   isVisible.value = false;
   propsData.value = {}; // 초기화

--- a/eatory-vueproject/src/stores/recordStore.js
+++ b/eatory-vueproject/src/stores/recordStore.js
@@ -35,7 +35,19 @@ apiClient.interceptors.request.use(
 // -------------------------------
 export function useRecordStore() {
   const records = ref([]); // 기록 데이터를 저장하는 상태
+  const selectedMenus = ref([]); // 선택된 메뉴 상태
   const { showToast } = useToastPopup(); // 토스트 팝업 사용
+
+  const selectedFood = ref(""); // 선택된 음식 상태 추가
+  
+  const setSelectedFood = (foodName) => {
+    selectedFood.value = foodName; // 선택된 음식 저장
+    console.log("선택된 음식 저장:", selectedFood.value);
+  }
+
+  const resetSelectedFood = () => {
+    selectedFood.value = "";
+  }
 
   // 특정 사용자의 기록 조회
   const getRecordsByUserId = async (userId) => {
@@ -95,11 +107,39 @@ export function useRecordStore() {
     }
   };
 
+  // 선택된 메뉴 추가
+  const addSelectedMenu = (menu) => {
+    if (!selectedMenus.value.some((item) => item.foodName === menu.foodName)) {
+      selectedMenus.value.push(menu);
+    } else {
+      showToast("이미 선택된 음식입니다.", 3000);
+    }
+  };
+
+  // 선택된 메뉴 삭제
+  const removeSelectedMenu = (foodName) => {
+    selectedMenus.value = selectedMenus.value.filter(
+      (item) => item.foodName !== foodName
+    );
+  };
+
+  // 선택된 메뉴 초기화
+  const resetSelectedMenus = () => {
+    selectedMenus.value = [];
+  };
+
   return {
     records, // 상태
+    selectedMenus,
+    addSelectedMenu,
+    removeSelectedMenu,
+    resetSelectedMenus,
     getRecordsByUserId,
     addRecord,
     updateRecord,
     deleteRecord,
+    selectedFood,
+    setSelectedFood,
+    resetSelectedFood,
   };
 }

--- a/eatory-vueproject/src/views/CalendarView.vue
+++ b/eatory-vueproject/src/views/CalendarView.vue
@@ -17,6 +17,8 @@ import CalendarComponent from "@/components/calendar/CalendarComponent.vue";
 import ModalPopup from "@/components/common/ModalPopup.vue";
 import ToastPopup from "@/components/common/ToastPopup.vue";
 import TestCalendarRecord from "@/components/calendar/TestCalendarRecord.vue";
+import CalendarRecord from "@/components/calendar/CalendarRecord.vue";
+
 import { useModal } from "@/stores/modalPopup";
 import { useToastPopup } from "@/stores/toastPopup";
 import { useRecordStore } from "@/stores/recordStore";
@@ -111,7 +113,7 @@ const openRecordModal = (date) => {
   };
 
   // `dayRecords`가 비어 있으면 기본값 사용
-  openModal("날짜 기록 추가/수정", TestCalendarRecord, {
+  openModal("날짜 기록 추가/수정", CalendarRecord, {
     date: formattedDate,
     existingRecordData: dayRecords.length > 0 ? dayRecords : defaultProps.existingRecordData,
   });

--- a/eatory-vueproject/vite.config.js
+++ b/eatory-vueproject/vite.config.js
@@ -15,4 +15,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://apis.data.go.kr', // 실제 API 서버
+        changeOrigin: true, // Origin 헤더 변경
+        rewrite: (path) => path.replace(/^\/api/, ''), // '/api' 제거
+      },
+    },
+  },
 })


### PR DESCRIPTION

## 📝 변경 사항
- **MealType별 Notes 독립 관리 기능 추가**
  - MealType에 따라 Notes를 분리하여 각각 저장 및 불러올 수 있도록 처리.

- **기존 기록 및 새 데이터 병합 로직 개선**
  - 동일 MealType에 기존 데이터가 있는 경우 병합하거나 독립적으로 추가.

- **검색 데이터 세션 동기화**
  - 검색창에서 선택한 메뉴가 세션에 저장되고, 이후 기록 모달에 자동 반영되도록 구현.

- **삭제 로직 안정화**
  - MealType에 따른 기록 삭제 기능 안정화 및 디버깅 로깅 추가.

- **즉각 반영 가능**
  - 새로고침 없이 기록 변경 사항이 UI에 실시간 반영되도록 최적화.

---

## ✅ 테스트 완료
- MealType별 Notes 추가, 수정, 삭제 정상 작동 확인.
- 검색 메뉴 세션 동기화 후 반영 테스트 완료.
- 삭제 시 UI 업데이트 및 데이터 동기화 문제 없음 확인.

---

## 📌 리뷰 요청 사항
- Notes 및 Menu 상태 동기화 관련 추가 개선점이 있는지 검토 부탁드립니다.
- 데이터 병합 로직에 대한 코드 리뷰 요청드립니다.
